### PR TITLE
Transform notations with var() alpha values

### DIFF
--- a/src/onCSSFunction.js
+++ b/src/onCSSFunction.js
@@ -92,8 +92,14 @@ const isAlphaLikeUnit = createRegExpTest(/^%?$/i)
 /** Return whether the unit is hue-like. */
 const isHueLikeUnit = createRegExpTest(/^(deg|grad|rad|turn)?$/i)
 
+/** Return whether the function name is `var`. */
+const isVarFunctionName = createRegExpTest(/^var$/i)
+
 /** @type {(node: CSSNumber) => boolean} Return whether the node is an Alpha-like unit. */
-const isAlphaValue = node => isCalc(node) || node.type === 'numeric' && isAlphaLikeUnit(node.unit)
+const isAlphaValue = node => isVar(node) || isCalc(node) || node.type === 'numeric' && isAlphaLikeUnit(node.unit)
+
+/** @type {(node: CSSFunction) => boolean} Return whether the node is a var() function. */
+const isVar = node => node.type === 'func' && isVarFunctionName(node.name)
 
 /** @type {(node: CSSFunction) => boolean} Return whether the node is a calc() function. */
 const isCalc = node => node.type === 'func' && isCalcFunctionName(node.name)

--- a/test/basic.css
+++ b/test/basic.css
@@ -12,6 +12,11 @@
 	color: rgba(178 34 34 / .5);
 }
 
+.test-rgb-functions {
+	color: rgb(178 34 34 / var(--text-opacity));
+	color: rgb(178 34 34 / calc(1 / 2));
+}
+
 .test-rgb-percentages {
 	color: rgba(70% 13.5% 13.5%);
 	color: rgba(70% 13.5% 13.5% / 100%);

--- a/test/basic.expect.css
+++ b/test/basic.expect.css
@@ -12,6 +12,11 @@
 	color: rgba(178, 34, 34, .5);
 }
 
+.test-rgb-functions {
+	color: rgba(178, 34, 34, var(--text-opacity));
+	color: rgba(178, 34, 34, calc(1 / 2));
+}
+
 .test-rgb-percentages {
 	color: rgb(178, 34, 34);
 	color: rgb(178, 34, 34);

--- a/test/basic.preserve-true.expect.css
+++ b/test/basic.preserve-true.expect.css
@@ -20,6 +20,13 @@
 	color: rgba(178 34 34 / .5);
 }
 
+.test-rgb-functions {
+	color: rgba(178, 34, 34, var(--text-opacity));
+	color: rgb(178 34 34 / var(--text-opacity));
+	color: rgba(178, 34, 34, calc(1 / 2));
+	color: rgb(178 34 34 / calc(1 / 2));
+}
+
 .test-rgb-percentages {
 	color: rgb(178, 34, 34);
 	color: rgba(70% 13.5% 13.5%);


### PR DESCRIPTION
This is specially useful for people working with TailwindCSS because 3.0 now outputs colors using this notation, but the alpha values are set to other tailwind variables. Here is an example of code generated by Tailwind:

```css
color: rgb(255 255 255 / var(--tw-text-opacity));
background-color: rgb(0 0 0 / var(--tw-bg-opacity));
```

Also added a test case for `calc()` values which were already supported.